### PR TITLE
Add simple vector database for podcast transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-test
+# Podcast Vector Database
+
+This project provides a minimal example of building a simple vector database for podcast transcripts using only the Python standard library.
+
+## Ingest transcripts
+
+Place your podcast transcript `.txt` files inside the `transcripts/` directory. Then run:
+
+```bash
+python -m vector_db.ingest_transcripts
+```
+
+This will create `db.json` containing term-frequency vectors for each transcript.
+
+## Search the database
+
+You can query the database from Python:
+
+```python
+from vector_db.vector_db import VectorDatabase
+
+# Load the database
+
+db = VectorDatabase('db.json')
+
+# Search for relevant transcripts
+results = db.search('technology and science')
+for doc_id, score in results:
+    print(doc_id, score)
+```

--- a/db.json
+++ b/db.json
@@ -1,0 +1,21 @@
+{
+  "documents": {
+    "sample": {
+      "welcome": 0.08333333333333333,
+      "to": 0.08333333333333333,
+      "our": 0.08333333333333333,
+      "first": 0.08333333333333333,
+      "podcast": 0.08333333333333333,
+      "episode.": 0.08333333333333333,
+      "we": 0.08333333333333333,
+      "talk": 0.08333333333333333,
+      "about": 0.08333333333333333,
+      "technology": 0.08333333333333333,
+      "and": 0.08333333333333333,
+      "science.": 0.08333333333333333
+    }
+  },
+  "texts": {
+    "sample": "Welcome to our first podcast episode. We talk about technology and science.\n"
+  }
+}

--- a/transcripts/sample.txt
+++ b/transcripts/sample.txt
@@ -1,0 +1,1 @@
+Welcome to our first podcast episode. We talk about technology and science.

--- a/vector_db/ingest_transcripts.py
+++ b/vector_db/ingest_transcripts.py
@@ -1,0 +1,21 @@
+import os
+from vector_db.vector_db import VectorDatabase
+
+
+def ingest(transcript_dir: str, db_path: str) -> None:
+    db = VectorDatabase(db_path)
+    for filename in os.listdir(transcript_dir):
+        if filename.endswith('.txt'):
+            path = os.path.join(transcript_dir, filename)
+            with open(path, 'r', encoding='utf-8') as f:
+                text = f.read()
+            doc_id = os.path.splitext(filename)[0]
+            db.add_document(doc_id, text)
+    db.save()
+
+
+if __name__ == '__main__':
+    transcript_dir = os.path.join(os.path.dirname(__file__), '..', 'transcripts')
+    db_path = os.path.join(os.path.dirname(__file__), '..', 'db.json')
+    ingest(transcript_dir, db_path)
+    print(f"Ingested transcripts from {transcript_dir} into {db_path}")

--- a/vector_db/vector_db.py
+++ b/vector_db/vector_db.py
@@ -1,0 +1,58 @@
+import json
+import math
+import os
+from collections import Counter
+from typing import Dict, List, Tuple
+
+
+def tokenize(text: str) -> List[str]:
+    """Simple whitespace tokenizer."""
+    return text.lower().split()
+
+
+def compute_tf(text: str) -> Dict[str, float]:
+    tokens = tokenize(text)
+    counts = Counter(tokens)
+    total = len(tokens)
+    return {token: count / total for token, count in counts.items()}
+
+
+def cosine_similarity(v1: Dict[str, float], v2: Dict[str, float]) -> float:
+    """Compute cosine similarity between two sparse vectors."""
+    common = set(v1) & set(v2)
+    numerator = sum(v1[t] * v2[t] for t in common)
+    sum1 = sum(v ** 2 for v in v1.values())
+    sum2 = sum(v ** 2 for v in v2.values())
+    denominator = math.sqrt(sum1) * math.sqrt(sum2)
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+class VectorDatabase:
+    def __init__(self, path: str):
+        self.path = path
+        self.documents: Dict[str, Dict[str, float]] = {}
+        self.texts: Dict[str, str] = {}
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                self.documents = data.get("documents", {})
+                self.texts = data.get("texts", {})
+
+    def add_document(self, doc_id: str, text: str) -> None:
+        self.texts[doc_id] = text
+        self.documents[doc_id] = compute_tf(text)
+
+    def search(self, query: str, top_k: int = 5) -> List[Tuple[str, float]]:
+        q_vec = compute_tf(query)
+        scores = [
+            (doc_id, cosine_similarity(q_vec, vec))
+            for doc_id, vec in self.documents.items()
+        ]
+        scores.sort(key=lambda x: x[1], reverse=True)
+        return scores[:top_k]
+
+    def save(self) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump({"documents": self.documents, "texts": self.texts}, f, indent=2)


### PR DESCRIPTION
## Summary
- implement minimal term-frequency based vector database
- add ingestion script for transcript text files and example transcript
- document usage for building and querying the database

## Testing
- `python -m vector_db.ingest_transcripts`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48781b364832590d3fb88dde5110c